### PR TITLE
Refactor unit test & coverage measurements.

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -47,6 +47,19 @@ jobs:
       with:
         version: v1.15.0
         args: -v test
-    
-  
+
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-go@v4
+      with:
+        go-version: '1.21'
+    - name: Coverage
+      uses: magefile/mage-action@v2
+      with:
+        version: v1.15.0
+        args: -v coverage
+
+
 

--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -17,6 +17,7 @@ package cmd
 
 import (
 	"context"
+	"os"
 
 	"github.com/jdaniecki/lynette/internal/runner"
 	"github.com/spf13/cobra"
@@ -27,10 +28,14 @@ var runCmd = &cobra.Command{
 	Use:   "run",
 	Short: "Create and execute bash in a new container",
 	Long:  ``,
-	RunE: func(cmd *cobra.Command, args []string) error {
+	Args:  cobra.MinimumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
 		ctx := context.Background()
-		runner := runner.New("/bin/bash", runner.WithNewNamespaces())
-		return runner.Run(ctx)
+		runner := runner.New(args[0], args[1:]...)
+		err := runner.Run(ctx)
+		if err != nil {
+			os.Exit(1)
+		}
 	},
 }
 
@@ -45,5 +50,5 @@ func init() {
 
 	// Cobra supports local flags which will only run when this command
 	// is called directly, e.g.:
-	// runCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+	//runCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
 }

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -15,43 +15,17 @@ type runner struct {
 	args       []string
 }
 
-type opt func(r *runner)
-
-// New is a configurable runner constructor
-func New(binary string, opts ...opt) *runner {
+// The runner constructor
+func New(binary string, args ...string) *runner {
 	r := &runner{}
 	r.binary = binary
-	r.attributes = &syscall.SysProcAttr{}
-
-	for _, o := range opts {
-		o(r)
+	r.args = args
+	r.attributes = &syscall.SysProcAttr{
+		Cloneflags:  syscall.CLONE_NEWUTS | syscall.CLONE_NEWIPC | syscall.CLONE_NEWPID | syscall.CLONE_NEWNET | syscall.CLONE_NEWUSER,
+		UidMappings: []syscall.SysProcIDMap{{ContainerID: 0, HostID: os.Getuid(), Size: 1}},
+		GidMappings: []syscall.SysProcIDMap{{ContainerID: 0, HostID: os.Getgid(), Size: 1}},
 	}
-
 	return r
-}
-
-// Runner option which configures executable binary arguments
-func WithArgs(args ...string) opt {
-	return func(r *runner) {
-		r.args = args
-	}
-}
-
-// Runner option which configures command to be executed in new UTS namespace
-func WithNewNamespaces() opt {
-	return func(r *runner) {
-		r.attributes.Cloneflags = syscall.CLONE_NEWUTS | syscall.CLONE_NEWIPC | syscall.CLONE_NEWPID | syscall.CLONE_NEWNET | syscall.CLONE_NEWUSER
-		r.attributes.UidMappings = append(r.attributes.UidMappings, syscall.SysProcIDMap{
-			ContainerID: 0,
-			HostID:      os.Getuid(),
-			Size:        1,
-		})
-		r.attributes.GidMappings = append(r.attributes.GidMappings, syscall.SysProcIDMap{
-			ContainerID: 0,
-			HostID:      os.Getgid(),
-			Size:        1,
-		})
-	}
 }
 
 // Run executes binary and waits until its completion

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -2,6 +2,7 @@ package runner_test
 
 import (
 	"context"
+	"os"
 	"os/exec"
 	"testing"
 	"time"
@@ -9,7 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-const lynetteBinary = "../../build/lynette"
+var lynetteBinary = os.Getenv("LYNETTE_BINARY_PATH")
 
 func TestRunSuccess(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -2,6 +2,7 @@ package runner_test
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"os/exec"
 	"testing"
@@ -11,6 +12,10 @@ import (
 )
 
 var lynetteBinary = os.Getenv("LYNETTE_BINARY_PATH")
+
+func init() {
+	fmt.Printf("Executing tests on %q\n", lynetteBinary)
+}
 
 func TestRunSuccess(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -2,30 +2,32 @@ package runner_test
 
 import (
 	"context"
+	"os/exec"
 	"testing"
 	"time"
 
-	"github.com/jdaniecki/lynette/internal/runner"
 	"github.com/stretchr/testify/assert"
 )
 
+const lynetteBinary = "../../build/lynette"
+
 func TestRunSuccess(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer cancel()
-	runner := runner.New("true")
-	assert.NoError(t, runner.Run(ctx))
+	cmd := exec.CommandContext(ctx, lynetteBinary, "run", "true")
+	assert.NoError(t, cmd.Run())
 }
 
 func TestRunFailure(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer cancel()
-	runner := runner.New("false")
-	assert.Error(t, runner.Run(ctx))
+	cmd := exec.CommandContext(ctx, lynetteBinary, "run", "false")
+	assert.Error(t, cmd.Run())
 }
 
 func TestRunTimeout(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	defer cancel()
-	runner := runner.New("sleep", runner.WithArgs("10"))
-	assert.Error(t, runner.Run(ctx))
+	cmd := exec.CommandContext(ctx, lynetteBinary, "run", "sleep", "10")
+	assert.Error(t, cmd.Run())
 }

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var lynetteBinary = os.Getenv("LYNETTE_BINARY_PATH")
@@ -16,19 +16,19 @@ func TestRunSuccess(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer cancel()
 	cmd := exec.CommandContext(ctx, lynetteBinary, "run", "true")
-	assert.NoError(t, cmd.Run())
+	require.NoError(t, cmd.Run())
 }
 
 func TestRunFailure(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer cancel()
 	cmd := exec.CommandContext(ctx, lynetteBinary, "run", "false")
-	assert.Error(t, cmd.Run())
+	require.Error(t, cmd.Run())
 }
 
 func TestRunTimeout(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 	cmd := exec.CommandContext(ctx, lynetteBinary, "run", "sleep", "10")
-	assert.Error(t, cmd.Run())
+	require.Error(t, cmd.Run())
 }

--- a/magefile.go
+++ b/magefile.go
@@ -33,16 +33,21 @@ func Build() error {
 
 // Execute unit tests
 func Test() error {
-	mg.Deps(Build)
+	mg.SerialDeps(Clean, Build)
+	wd, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+	buildDir := path.Join(wd, "build")
 	env := map[string]string{
-		"LYNETTE_BINARY_PATH": "../../build/lynette",
+		"LYNETTE_BINARY_PATH": filepath.Join(buildDir, "lynette"),
 	}
 	return sh.RunWith(env, "go", "test", "-v", "./...")
 }
 
 // Measure source code test coverage
 func Coverage() error {
-	mg.Deps(Build)
+	mg.SerialDeps(Clean, Build)
 
 	wd, err := os.Getwd()
 	if err != nil {

--- a/magefile.go
+++ b/magefile.go
@@ -5,6 +5,8 @@ package main
 
 import (
 	"os"
+	"path"
+	"path/filepath"
 
 	"github.com/magefile/mage/mg"
 	"github.com/magefile/mage/sh"
@@ -15,9 +17,18 @@ func Lint() error {
 	return sh.Run("golangci-lint", "run")
 }
 
+func buildGeneric() error {
+	return sh.Run("go", "build", "-o", "./build/lynette", "cmd/lynette/lynette.go")
+}
+
+func buildCoverage() error {
+	return sh.Run("go", "build", "-cover", "-o", "./build/lynette_coverage", "cmd/lynette/lynette.go")
+}
+
 // Build lynette binary
 func Build() error {
-	return sh.Run("go", "build", "-o", "./build/lynette", "cmd/lynette/lynette.go")
+	mg.Deps(buildGeneric, buildCoverage)
+	return nil
 }
 
 // Execute unit tests
@@ -31,17 +42,34 @@ func Test() error {
 
 // Measure source code test coverage
 func Coverage() error {
+	mg.Deps(Build)
+
+	wd, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+	buildDir := path.Join(wd, "build")
+	coverageDir := path.Join(buildDir)
 	env := map[string]string{
-		"LYNETTE_BINARY_PATH": "../../build/lynette",
+		"LYNETTE_BINARY_PATH": path.Join(buildDir, "lynette_coverage"),
+		"GOCOVERDIR":          coverageDir,
 	}
 
-	if err := sh.RunWith(env, "go", "test", "-v", "./...", "-cover", "-coverprofile=build/coverage.out", "-covermode=count"); err != nil {
+	if err := sh.RunWith(env, "go", "test", "-v", "./..."); err != nil {
 		return err
 	}
-	if err := sh.Run("go", "tool", "cover", "-func=build/coverage.out"); err != nil {
+
+	if err := sh.RunWith(env, "go", "tool", "covdata", "percent", "-i", coverageDir); err != nil {
 		return err
 	}
-	if err := sh.Run("go", "tool", "cover", "-html=build/coverage.out", "-o=build/coverage.html"); err != nil {
+
+	coveragePath := filepath.Join(coverageDir, "coverage.out")
+	if err := sh.RunWith(env, "go", "tool", "covdata", "textfmt", "-i", coverageDir, "-o", coveragePath); err != nil {
+		return err
+	}
+
+	reportPath := filepath.Join(coverageDir, "coverage.html")
+	if err := sh.Run("go", "tool", "cover", "-html", coveragePath, "-o", reportPath); err != nil {
 		return err
 	}
 	return nil

--- a/magefile.go
+++ b/magefile.go
@@ -23,12 +23,19 @@ func Build() error {
 // Execute unit tests
 func Test() error {
 	mg.Deps(Build)
-	return sh.Run("go", "test", "-v", "./...")
+	env := map[string]string{
+		"LYNETTE_BINARY_PATH": "../../build/lynette",
+	}
+	return sh.RunWith(env, "go", "test", "-v", "./...")
 }
 
 // Measure source code test coverage
 func Coverage() error {
-	if err := sh.Run("go", "test", "-v", "./...", "-cover", "-coverprofile=build/coverage.out", "-covermode=count"); err != nil {
+	env := map[string]string{
+		"LYNETTE_BINARY_PATH": "../../build/lynette",
+	}
+
+	if err := sh.RunWith(env, "go", "test", "-v", "./...", "-cover", "-coverprofile=build/coverage.out", "-covermode=count"); err != nil {
 		return err
 	}
 	if err := sh.Run("go", "tool", "cover", "-func=build/coverage.out"); err != nil {

--- a/magefile.go
+++ b/magefile.go
@@ -6,6 +6,7 @@ package main
 import (
 	"os"
 
+	"github.com/magefile/mage/mg"
 	"github.com/magefile/mage/sh"
 )
 
@@ -21,6 +22,7 @@ func Build() error {
 
 // Execute unit tests
 func Test() error {
+	mg.Deps(Build)
 	return sh.Run("go", "test", "-v", "./...")
 }
 


### PR DESCRIPTION
```sh
jdaniecki@DESKTOP-E1G5ILB:~/projects/lynette$ mage -v coverage
Running target: Coverage
Running dependency: Build
Running dependency: buildCoverage
Running dependency: buildGeneric
exec: go "build" "-cover" "-o" "./build/lynette_coverage" "cmd/lynette/lynette.go"
exec: go "build" "-o" "./build/lynette" "cmd/lynette/lynette.go"
exec: go "test" "-v" "./..."
?       github.com/jdaniecki/lynette/cmd/lynette        [no test files]
?       github.com/jdaniecki/lynette/internal/cmd       [no test files]
=== RUN   TestRunSuccess
--- PASS: TestRunSuccess (0.01s)
=== RUN   TestRunFailure
--- PASS: TestRunFailure (0.01s)
=== RUN   TestRunTimeout
--- PASS: TestRunTimeout (2.00s)
PASS
ok      github.com/jdaniecki/lynette/internal/runner    2.014s
exec: go "tool" "covdata" "percent" "-i" "/home/jdaniecki/projects/lynette/build"
        command-line-arguments          coverage: 100.0% of statements
        github.com/jdaniecki/lynette/internal/cmd               coverage: 85.7% of statements
        github.com/jdaniecki/lynette/internal/runner            coverage: 95.0% of statements
exec: go "tool" "covdata" "textfmt" "-i" "/home/jdaniecki/projects/lynette/build" "-o" "/home/jdaniecki/projects/lynette/build/coverage.out"
exec: go "tool" "cover" "-html" "/home/jdaniecki/projects/lynette/build/coverage.out" "-o" "/home/jdaniecki/projects/lynette/build/coverage.html"
```

![image](https://github.com/jdaniecki/lynette/assets/11823991/d50d6564-4cd0-4520-bc18-5407166ff435)
![image](https://github.com/jdaniecki/lynette/assets/11823991/956352ac-0d41-42d0-abbc-5d37007ea162)
